### PR TITLE
Added Parens around license

### DIFF
--- a/aurpush
+++ b/aurpush
@@ -30,7 +30,7 @@ create_pkg() {
   echo "pkgrel=1" >> PKGBUILD
   echo "pkgdesc=""\"Description"\""" >> PKGBUILD
   echo "url=""\"http://github.com/<USERNAME>/${pkgname}"\""" >> PKGBUILD
-  echo "license=""\"None"\""" >> PKGBUILD
+  echo "license=(\"None\")" >> PKGBUILD
   echo "arch=('any')" >> PKGBUILD
   echo "makedepends=('')" >> PKGBUILD
   echo "depends=('')" >> PKGBUILD


### PR DESCRIPTION
You need these to build on some modern systems

I don't understand why there were so many quotation marks to begin with, so this might not work.

The correct line is

```
license=("None")
```
